### PR TITLE
Image support improvements

### DIFF
--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -2,6 +2,7 @@
 
 #include <MaterialXGenShader/Util.h>
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>
+#include <MaterialXGenShader/HwShader.h>
 
 #include <iostream>
 
@@ -43,7 +44,7 @@ void loadLibraries(const mx::StringVec& libraryNames, const mx::FilePath& search
     }
 }
 
-StringPair generateSource(const mx::FilePath& filePath, const mx::FilePath& searchPath, mx::DocumentPtr stdLib)
+StringPair generateSource(const mx::FilePath& filePath, const mx::FilePath& searchPath, mx::DocumentPtr stdLib, mx::HwShaderPtr& hwShader)
 {
     mx::DocumentPtr doc = mx::createDocument();
     mx::readFromXmlFile(doc, filePath);
@@ -81,26 +82,37 @@ StringPair generateSource(const mx::FilePath& filePath, const mx::FilePath& sear
 
     mx::GenOptions options;
     options.shaderInterfaceType = mx::SHADER_INTERFACE_REDUCED;
-    options.hwTransparency = false;
+    options.hwTransparency = isTransparentSurface(elem, *shaderGenerator);
     mx::ShaderPtr sgShader = shaderGenerator->generate("Shader", elem, options);
 
     std::string vertexShader = sgShader->getSourceCode(mx::HwShader::VERTEX_STAGE);
     std::string pixelShader = sgShader->getSourceCode(mx::HwShader::PIXEL_STAGE);
 
+    hwShader = std::dynamic_pointer_cast<mx::HwShader>(sgShader);
+
     return StringPair(vertexShader, pixelShader);
 }
 
-ShaderPtr generateShader(const mx::FilePath& filePath, const mx::FilePath& searchPath, mx::DocumentPtr stdLib)
+ViewerShaderPtr ViewerShader::generateShader(const mx::FilePath& filePath, const mx::FilePath& searchPath, mx::DocumentPtr stdLib )
 {
-    ShaderPtr shader = ShaderPtr(new ng::GLShader);
-    StringPair source = generateSource(filePath, searchPath, stdLib);
-    shader->init(filePath.getBaseName(), source.first, source.second);
-    return shader;
+    mx::HwShaderPtr hwShader = nullptr;
+    StringPair source = generateSource(filePath, searchPath, stdLib, hwShader);
+    if (!source.first.empty() && !source.second.empty())
+    {
+        GLShaderPtr ngShader = GLShaderPtr(new ng::GLShader());
+        ngShader->init(filePath.getBaseName(), source.first, source.second);
+
+        ViewerShaderPtr shader = ViewerShaderPtr(new ViewerShader(ngShader, hwShader));
+        shader->_isTransparent = hwShader ? hwShader->hasTransparency() : false;
+
+        return shader;
+    }
+    return nullptr;
 }
 
-void bindMesh(ShaderPtr& shader, MeshPtr& mesh)
+void ViewerShader::bindMesh(MeshPtr& mesh)
 {
-    if (!mesh)
+    if (!mesh || !_ngShader)
     {
         return;
     }
@@ -111,17 +123,76 @@ void bindMesh(ShaderPtr& shader, MeshPtr& mesh)
     MatrixXfProxy texcoords(&mesh->getTexcoords()[0][0], 2, mesh->getTexcoords().size());
     MatrixXuProxy indices(&mesh->getIndices()[0], 3, mesh->getIndices().size() / 3);
 
-    shader->bind();
-    shader->uploadAttrib("i_position", positions);
-    shader->uploadAttrib("i_normal", normals);
-    shader->uploadAttrib("i_tangent", tangents);
-    shader->uploadAttrib("i_texcoord_0", texcoords);
-    shader->uploadIndices(indices);
+    _ngShader->bind();
+    _ngShader->uploadAttrib("i_position", positions);
+    _ngShader->uploadAttrib("i_normal", normals);
+    _ngShader->uploadAttrib("i_tangent", tangents);
+    _ngShader->uploadAttrib("i_texcoord_0", texcoords);
+    _ngShader->uploadIndices(indices);
 }
 
-void bindUniforms(ShaderPtr& shader, mx::ImageHandlerPtr imageHandler, mx::FilePath imagePath, int envSamples,
+void ViewerShader::bindUniforms(mx::ImageHandlerPtr imageHandler, mx::FilePath imagePath, int envSamples,
                   mx::Matrix44& world, mx::Matrix44& view, mx::Matrix44& proj)
 {
+    GLShaderPtr shader = ngShader();
+    mx::HwShaderPtr hwShader = mxShader();
+
+    int textureUnit = 0;
+    const MaterialX::Shader::VariableBlock publicUniforms = hwShader->getUniformBlock(MaterialX::Shader::PIXEL_STAGE, MaterialX::Shader::PUBLIC_UNIFORMS);
+    for (auto uniform : publicUniforms.variableOrder)
+    {
+        if (uniform->type != MaterialX::Type::FILENAME)
+        {
+            continue;
+        }
+        const std::string& samplerName = uniform->name;
+        const std::string& fileName = uniform->value ? uniform->value->getValueString() : "";
+        const std::string kTEXTUREPOSTFIX("_texture");
+        std::string textureName = samplerName + kTEXTUREPOSTFIX;
+
+        ImageDesc desc;
+        if (imageCache.count(fileName))
+        {
+            desc = imageCache[fileName];
+        }
+        else
+        {
+            // Load the requested texture into memory.
+            float* data = nullptr;
+            if (!imageHandler->loadImage(fileName, desc.width, desc.height, desc.channelCount, &data))
+            {
+                std::cerr << "Failed to load image: " << fileName << std::endl;
+                continue;
+            }
+            desc.mipCount = (unsigned int)std::log2(std::max(desc.width, desc.height)) + 1;
+
+            // Upload texture and generate mipmaps.
+            glGenTextures(1, &desc.textureId);
+            glActiveTexture(GL_TEXTURE0 + desc.textureId);
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+            glBindTexture(GL_TEXTURE_2D, desc.textureId);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, desc.width, desc.height, 0,
+                (desc.channelCount == 4 ? GL_RGBA : GL_RGB), GL_FLOAT, data);
+            glGenerateMipmap(GL_TEXTURE_2D);
+
+            // Free memory buffer.
+            free(data);
+
+            imageCache[fileName] = desc;
+        }
+
+        // Bind texture to shader.
+        shader->setUniform(uniform->name, desc.textureId);
+        glActiveTexture(GL_TEXTURE0 + desc.textureId);
+        glBindTexture(GL_TEXTURE_2D, desc.textureId);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+
+        textureUnit++;
+    }
+
     mx::Matrix44 viewProj = proj * view;
     mx::Matrix44 invView = view.getInverse();
     mx::Matrix44 invTransWorld = world.getInverse().getTranspose();
@@ -144,7 +215,6 @@ void bindUniforms(ShaderPtr& shader, mx::ImageHandlerPtr imageHandler, mx::FileP
     {
         shader->setUniform("u_envSamples", envSamples);
     }
-    int textureUnit = 0;
     mx::StringMap lightTextures = {
         {"u_envRadiance", "documents/TestSuite/Images/san_giuseppe_bridge.exr" },
         {"u_envIrradiance", "documents/TestSuite/Images/san_giuseppe_bridge_diffuse.exr" }

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -82,7 +82,7 @@ StringPair generateSource(const mx::FilePath& filePath, const mx::FilePath& sear
     return StringPair(vertexShader, pixelShader);
 }
 
-MaterialPtr Material::generateShader(const mx::FilePath& filePath, const mx::FilePath& searchPath, mx::DocumentPtr stdLib )
+MaterialPtr Material::generateShader(const mx::FilePath& filePath, const mx::FilePath& searchPath, mx::DocumentPtr stdLib)
 {
     mx::HwShaderPtr hwShader = nullptr;
     StringPair source = generateSource(filePath, searchPath, stdLib, hwShader);
@@ -106,7 +106,7 @@ void Material::bindMesh(MeshPtr& mesh)
         return;
     }
 
-    // This needs to be reversed to examine the MaterialX shader for required attributes
+    // TODO: This needs to be reversed to examine the MaterialX shader for required attributes
     _ngShader->bind();
     if (_ngShader->attrib("i_position") != -1)
     {
@@ -132,19 +132,19 @@ void Material::bindMesh(MeshPtr& mesh)
     _ngShader->uploadIndices(indices);
 }
 
-bool Material::acquireTexture(const std::string& fileName, mx::ImageHandlerPtr imageHandler, ImageDesc &desc)
+bool Material::acquireTexture(const std::string& filename, mx::ImageHandlerPtr imageHandler, ImageDesc& desc)
 {
-    if (imageCache.count(fileName))
+    if (imageCache.count(filename))
     {
-        desc = imageCache[fileName];
+        desc = imageCache[filename];
     }
     else
     {
         // Load the requested texture into memory.
         float* data = nullptr;
-        if (!imageHandler->loadImage(fileName, desc.width, desc.height, desc.channelCount, &data))
+        if (!imageHandler->loadImage(filename, desc.width, desc.height, desc.channelCount, &data))
         {
-            std::cerr << "Failed to load image: " << fileName << std::endl;
+            std::cerr << "Failed to load image: " << filename << std::endl;
             return false;
         }
         desc.mipCount = (unsigned int)std::log2(std::max(desc.width, desc.height)) + 1;
@@ -161,12 +161,12 @@ bool Material::acquireTexture(const std::string& fileName, mx::ImageHandlerPtr i
         // Free memory buffer.
         free(data);
 
-        imageCache[fileName] = desc;
+        imageCache[filename] = desc;
     }
     return true;
 }
 
-bool Material::bindTexture(const std::string& fileName, const std::string& uniformName, 
+bool Material::bindTexture(const std::string& filename, const std::string& uniformName, 
                            mx::ImageHandlerPtr imageHandler, ImageDesc& desc)
 {
     if (!_ngShader)
@@ -175,7 +175,7 @@ bool Material::bindTexture(const std::string& fileName, const std::string& unifo
     }
 
     _ngShader->bind();
-      if (acquireTexture(fileName, imageHandler, desc))
+      if (acquireTexture(filename, imageHandler, desc))
     {
         // Bind texture to shader.
         _ngShader->setUniform(uniformName, desc.textureId);
@@ -203,10 +203,10 @@ void Material::bindTextures(mx::ImageHandlerPtr imageHandler)
             continue;
         }
         const std::string& uniformName = uniform->name;
-        const std::string& fileName = uniform->value ? uniform->value->getValueString() : "";
+        const std::string& filename = uniform->value ? uniform->value->getValueString() : "";
 
         ImageDesc desc;
-        bindTexture(fileName, uniformName, imageHandler, desc);
+        bindTexture(filename, uniformName, imageHandler, desc);
     }
 }
 
@@ -251,10 +251,10 @@ void Material::bindUniforms(mx::ImageHandlerPtr imageHandler, mx::FilePath image
         {
             // Access cached image or load from disk.
             mx::FilePath path = imagePath / mx::FilePath(pair.second);
-            const std::string fileName = path.asString();
+            const std::string filename = path.asString();
 
             ImageDesc desc;
-            if (bindTexture(fileName, pair.first, imageHandler, desc))
+            if (bindTexture(filename, pair.first, imageHandler, desc))
             {
                 // Bind any associated uniforms.
                 if (pair.first == "u_envRadiance")

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -19,32 +19,60 @@ namespace ng = nanogui;
 using StringPair = std::pair<std::string, std::string>;
 using GLShaderPtr = std::shared_ptr<ng::GLShader>;
 
-using ViewerShaderPtr = std::unique_ptr<class ViewerShader>;
+using MaterialPtr = std::unique_ptr<class Material>;
 
-class ViewerShader
+// TODO: Move image caching into the ImageHandler class.
+class ImageDesc
+{
+public:
+    unsigned int width = 0; // TODO: These would be better as size_t.
+    unsigned int height = 0;
+    unsigned int channelCount = 0;
+    unsigned int mipCount = 0;
+    unsigned int textureId = 0;
+};
+
+class Material
 {
   public:
-    static ViewerShaderPtr generateShader(const mx::FilePath& filePath, const mx::FilePath& searchPath, mx::DocumentPtr stdLib);
+    static MaterialPtr generateShader(const mx::FilePath& filePath, const mx::FilePath& searchPath, mx::DocumentPtr stdLib);
 
+    /// Get Nano-gui shader
     GLShaderPtr ngShader() const { return _ngShader; }
+    
+    /// Get MaterialX shader
     mx::HwShaderPtr mxShader() const { return _mxShader; }
 
+    /// Bind mesh inputs to shader
     void bindMesh(MeshPtr& mesh);
+
+    /// Bind uniforms to shader
     void bindUniforms(mx::ImageHandlerPtr imageHandler, mx::FilePath imagePath, int envSamples,
                       mx::Matrix44& world, mx::Matrix44& view, mx::Matrix44& proj);
 
-    bool isTransparent() const { return _isTransparent; }
+    /// Bind texture to shader
+    bool bindTexture(const std::string& fileName, const std::string& uniformName,
+                     mx::ImageHandlerPtr imageHandler, ImageDesc& desc);
+
+    /// Bind required file textures to shader
+    void Material::bindTextures(mx::ImageHandlerPtr imageHandler);
+
+    /// Return if the shader is has transparency
+    bool hasTransparency() const { return _hasTransparency; }
 
   protected:
-    ViewerShader(GLShaderPtr ngshader, mx::HwShaderPtr mxshader)
+    Material(GLShaderPtr ngshader, mx::HwShaderPtr mxshader)
     {
         _ngShader = ngshader;
         _mxShader = mxshader;
     }
 
+    // Acquire a texture. Return information in image description
+    bool acquireTexture(const std::string& fileName, mx::ImageHandlerPtr imageHandler, ImageDesc &desc);
+
     GLShaderPtr _ngShader;
     mx::HwShaderPtr _mxShader;
-    bool _isTransparent;
+    bool _hasTransparency;
 };
 
 void loadLibraries(const mx::StringVec& libraryNames, const mx::FilePath& searchPath, mx::DocumentPtr doc);

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -68,7 +68,7 @@ class Material
     }
 
     // Acquire a texture. Return information in image description
-    bool acquireTexture(const std::string& fileName, mx::ImageHandlerPtr imageHandler, ImageDesc &desc);
+    bool acquireTexture(const std::string& filename, mx::ImageHandlerPtr imageHandler, ImageDesc& desc);
 
     GLShaderPtr _ngShader;
     mx::HwShaderPtr _mxShader;

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -41,9 +41,9 @@ Viewer::Viewer() :
             _mesh = MeshPtr(new Mesh());
             if (_mesh->loadMesh(filename))
             {
-                if (_viewerShader)
+                if (_material)
                 {
-                    _viewerShader->bindMesh(_mesh);
+                    _material->bindMesh(_mesh);
                 }
                 recenterCamera();
             }
@@ -66,10 +66,10 @@ Viewer::Viewer() :
             _materialFilename = filename;
             try
             {
-                _viewerShader = ViewerShader::generateShader(_materialFilename, _searchPath, _stdLib);
-                if (_viewerShader)
+                _material = Material::generateShader(_materialFilename, _searchPath, _stdLib);
+                if (_material)
                 {
-                    _viewerShader->bindMesh(_mesh);
+                    _material->bindMesh(_mesh);
                 }
             }
             catch (std::exception& e)
@@ -110,10 +110,10 @@ Viewer::Viewer() :
 
     try
     {
-        _viewerShader = ViewerShader::generateShader(_materialFilename, _searchPath, _stdLib);
-        if (_viewerShader)
+        _material = Material::generateShader(_materialFilename, _searchPath, _stdLib);
+        if (_material)
         {
-            _viewerShader->bindMesh(_mesh);
+            _material->bindMesh(_mesh);
         }
     }
     catch (std::exception& e)
@@ -134,10 +134,10 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
         {
             try
             {
-                _viewerShader = ViewerShader::generateShader(_materialFilename, _searchPath, _stdLib);
-                if (_viewerShader)
+                _material = Material::generateShader(_materialFilename, _searchPath, _stdLib);
+                if (_material)
                 {
-                    _viewerShader->bindMesh(_mesh);
+                    _material->bindMesh(_mesh);
                 }
             }
             catch (std::exception& e)
@@ -172,7 +172,7 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
 
 void Viewer::drawContents()
 {
-    if (!_mesh || !_viewerShader)
+    if (!_mesh || !_material)
     {
         return;
     }
@@ -180,15 +180,15 @@ void Viewer::drawContents()
     mx::Matrix44 world, view, proj;
     computeCameraMatrices(world, view, proj);
 
-    GLShaderPtr shader = _viewerShader->ngShader();
+    GLShaderPtr shader = _material->ngShader();
     shader->bind();
 
-    _viewerShader->bindUniforms(_imageHandler, _startPath, _envSamples, world, view, proj);
+    _material->bindUniforms(_imageHandler, _startPath, _envSamples, world, view, proj);
 
     glEnable(GL_DEPTH_TEST);
     glDisable(GL_CULL_FACE);
     glEnable(GL_FRAMEBUFFER_SRGB);
-    if (_viewerShader->isTransparent())
+    if (_material->hasTransparency())
     {
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -41,7 +41,10 @@ Viewer::Viewer() :
             _mesh = MeshPtr(new Mesh());
             if (_mesh->loadMesh(filename))
             {
-                bindMesh(_glShader, _mesh);
+                if (_viewerShader)
+                {
+                    _viewerShader->bindMesh(_mesh);
+                }
                 recenterCamera();
             }
             else
@@ -63,8 +66,11 @@ Viewer::Viewer() :
             _materialFilename = filename;
             try
             {
-                _glShader = generateShader(_materialFilename, _searchPath, _stdLib);
-                bindMesh(_glShader, _mesh);
+                _viewerShader = ViewerShader::generateShader(_materialFilename, _searchPath, _stdLib);
+                if (_viewerShader)
+                {
+                    _viewerShader->bindMesh(_mesh);
+                }
             }
             catch (std::exception& e)
             {
@@ -104,8 +110,11 @@ Viewer::Viewer() :
 
     try
     {
-        _glShader = generateShader(_materialFilename, _searchPath, _stdLib);
-        bindMesh(_glShader, _mesh);
+        _viewerShader = ViewerShader::generateShader(_materialFilename, _searchPath, _stdLib);
+        if (_viewerShader)
+        {
+            _viewerShader->bindMesh(_mesh);
+        }
     }
     catch (std::exception& e)
     {
@@ -125,8 +134,11 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
         {
             try
             {
-                _glShader = generateShader(_materialFilename, _searchPath, _stdLib);
-                bindMesh(_glShader, _mesh);
+                _viewerShader = ViewerShader::generateShader(_materialFilename, _searchPath, _stdLib);
+                if (_viewerShader)
+                {
+                    _viewerShader->bindMesh(_mesh);
+                }
             }
             catch (std::exception& e)
             {
@@ -141,7 +153,8 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
         {
             try
             {
-                StringPair source = generateSource(_materialFilename, _searchPath, _stdLib);
+                mx::HwShaderPtr hwShader = nullptr;
+                StringPair source = generateSource(_materialFilename, _searchPath, _stdLib, hwShader);
                 std::string baseName = mx::splitString(_materialFilename.getBaseName(), ".")[0];
                 mx::StringVec splitName = mx::splitString(baseName, ".");
                 writeTextFile(source.first, _startPath / (baseName + "_vs.glsl"));
@@ -159,7 +172,7 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
 
 void Viewer::drawContents()
 {
-    if (!_mesh || !_glShader)
+    if (!_mesh || !_viewerShader)
     {
         return;
     }
@@ -167,16 +180,27 @@ void Viewer::drawContents()
     mx::Matrix44 world, view, proj;
     computeCameraMatrices(world, view, proj);
 
-    _glShader->bind();
+    GLShaderPtr shader = _viewerShader->ngShader();
+    shader->bind();
 
-    bindUniforms(_glShader, _imageHandler, _startPath, _envSamples, world, view, proj);
+    _viewerShader->bindUniforms(_imageHandler, _startPath, _envSamples, world, view, proj);
 
     glEnable(GL_DEPTH_TEST);
     glDisable(GL_CULL_FACE);
     glEnable(GL_FRAMEBUFFER_SRGB);
+    if (_viewerShader->isTransparent())
+    {
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    }
+    else
+    {
+        glDisable(GL_BLEND);
+    }
 
-    _glShader->drawIndexed(GL_TRIANGLES, 0, (uint32_t) _mesh->getFaceCount());
+    shader->drawIndexed(GL_TRIANGLES, 0, (uint32_t) _mesh->getFaceCount());
 
+    glDisable(GL_BLEND);
     glDisable(GL_FRAMEBUFFER_SRGB);
 }
 

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -49,7 +49,7 @@ class Viewer : public ng::Screen
   private:
     ng::Window* _window;
     std::unique_ptr<Mesh> _mesh;
-    ViewerShaderPtr _viewerShader;
+    MaterialPtr _material;
 
     CameraParameters _cameraParams;
     bool _translationActive;

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -3,6 +3,7 @@
 
 #include <MaterialXView/Material.h>
 #include <MaterialXView/Mesh.h>
+#include <MaterialXGenShader/HwShader.h>
 
 #include <nanogui/glutil.h>
 #include <nanogui/screen.h>
@@ -48,7 +49,7 @@ class Viewer : public ng::Screen
   private:
     ng::Window* _window;
     std::unique_ptr<Mesh> _mesh;
-    ShaderPtr _glShader;
+    ViewerShaderPtr _viewerShader;
 
     CameraParameters _cameraParams;
     bool _translationActive;


### PR DESCRIPTION
- Add in wrapper for a "material" class which can hold a nano-gui shader as well as reference to the input MaterialX shader. 
- The MaterialX shader provides access to uniforms which can be bound. For now additional parse to find input file textures has been added, and checking for transparency to allow for some basic alpha blending at draw time.
