### PR TITLE
Add material list support

### DIFF
--- a/source/MaterialXGenShader/Nodes/ConvolutionNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ConvolutionNode.cpp
@@ -161,7 +161,7 @@ void ConvolutionNode::emitInputSamplesUV(const ShaderNode& node, GenContext& con
     }
     else
     {
-        if (inInput->value)
+        if (!inInput->value)
         {
             throw ExceptionShaderGenError("No connection or value found on node: '" + node.getName() + "'");
         }

--- a/source/MaterialXGenShader/Nodes/ConvolutionNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ConvolutionNode.cpp
@@ -161,7 +161,7 @@ void ConvolutionNode::emitInputSamplesUV(const ShaderNode& node, GenContext& con
     }
     else
     {
-        if (!inInput->value)
+        if (inInput->value)
         {
             throw ExceptionShaderGenError("No connection or value found on node: '" + node.getName() + "'");
         }
@@ -173,7 +173,7 @@ void ConvolutionNode::emitInputSamplesUV(const ShaderNode& node, GenContext& con
 
         if (inInput->type->isScalar())
         {
-            string scalarValueString = inInput->value->getValueString();
+            string scalarValueString = inInput->value ? inInput->value->getValueString() : "1";
             for (unsigned int i = 0; i < _sampleCount; i++)
             {
                 sampleStrings.push_back(scalarValueString);

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -414,7 +414,7 @@ bool isTransparentSurface(ElementPtr element, const ShaderGenerator& shadergen)
                 {
                     // Unconnected, check the value
                     ValuePtr value = opacity->getValue();
-                    if (!value || isWhite(value->asA<Color3>()))
+                    if (!value || value->isA<Color3>() && isWhite(value->asA<Color3>()))
                     {
                         opaque = true;
                     }

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -186,6 +186,11 @@ namespace
         for (GraphIterator it = output->traverseGraph().begin(); it != GraphIterator::end(); ++it)
         {
             ElementPtr upstreamElem = it.getUpstreamElement();
+            if (!upstreamElem)
+            {
+                it.setPruneSubgraph(true);
+                continue;
+            }
 
             const string& typeName = upstreamElem->asA<TypedElement>()->getType();
             const TypeDesc* type = TypeDesc::get(typeName);

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -414,7 +414,7 @@ bool isTransparentSurface(ElementPtr element, const ShaderGenerator& shadergen)
                 {
                     // Unconnected, check the value
                     ValuePtr value = opacity->getValue();
-                    if (!value || value->isA<Color3>() && isWhite(value->asA<Color3>()))
+                    if (!value || (value->isA<Color3>() && isWhite(value->asA<Color3>())))
                     {
                         opaque = true;
                     }

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -56,6 +56,7 @@ void loadDocument(const mx::FilePath& filePath, mx::DocumentPtr& doc, mx::Docume
             {
                 if (!shaderRef->hasSourceUri())
                 {
+                    // Add in all shader references which are not part of a node definition library
                     elements.push_back(shaderRef);
 
                     // Find all bindinputs which reference outputs and outputgraphs
@@ -80,8 +81,7 @@ void loadDocument(const mx::FilePath& filePath, mx::DocumentPtr& doc, mx::Docume
                 std::vector<mx::OutputPtr> nodeGraphOutputs = nodeGraph->getOutputs();
                 for (mx::OutputPtr output : nodeGraphOutputs)
                 {
-                    // For now we skip any outputs which are referenced elsewhere.
-                    // TODO: We could add an option to also validate them.
+                    // We skip any outputs which are referenced elsewhere.
                     if (shaderrefOutputs.count(output) == 0)
                     {
                         outputSet.insert(output);
@@ -90,7 +90,7 @@ void loadDocument(const mx::FilePath& filePath, mx::DocumentPtr& doc, mx::Docume
             }
         }
 
-        // Run validation on the outputs
+        // Add ouptuts which are not part of library definitions
         for (mx::OutputPtr output : outputSet)
         {
             // Skip anything from include files
@@ -100,25 +100,6 @@ void loadDocument(const mx::FilePath& filePath, mx::DocumentPtr& doc, mx::Docume
             }
         }
     }
-#if 0
-    mx::ElementPtr elem = nullptr;
-    for (mx::MaterialPtr material : doc->getMaterials())
-    {
-        std::vector<mx::ShaderRefPtr> shaderRefs = material->getShaderRefs();
-        for (auto shaderRef : shaderRefs)
-        {
-            elements.push_back(shaderRef);
-        }
-    }
-    for (mx::NodeGraphPtr nodeGraph : doc->getNodeGraphs())
-    {
-        std::vector<mx::OutputPtr> outputs = nodeGraph->getOutputs();
-        for (auto output : outputs)
-        {
-            elements.push_back(output);
-        }
-    }
-#endif
 }
 
 StringPair generateSource(const mx::FilePath& searchPath, mx::HwShaderPtr& hwShader, mx::ElementPtr elem)

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -113,7 +113,6 @@ StringPair generateSource(const mx::FilePath& searchPath, mx::HwShaderPtr& hwSha
     shaderGenerator->registerSourceCodeSearchPath(searchPath);
 
     mx::GenOptions options;
-    options.shaderInterfaceType = mx::SHADER_INTERFACE_REDUCED;
     options.hwTransparency = isTransparentSurface(elem, *shaderGenerator);
     mx::ShaderPtr sgShader = shaderGenerator->generate("Shader", elem, options);
 

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -269,7 +269,15 @@ void Material::bindTextures(mx::ImageHandlerPtr imageHandler, mx::FilePath image
         std::string filename;
         if (uniform->value)
         {
-            filename = imagePath / uniform->value->getValueString();
+            mx::FilePath uniformPath(uniform->value->getValueString());
+            if (uniformPath.isAbsolute())
+            {
+                filename = uniformPath;
+            }
+            else
+            {
+                filename = imagePath / uniformPath;
+            }
         }
 
         ImageDesc desc;

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -35,7 +35,7 @@ class ImageDesc
 class Material
 {
   public:
-    static MaterialPtr generateShader(const mx::FilePath& filePath, const mx::FilePath& searchPath, mx::DocumentPtr stdLib);
+    static MaterialPtr generateShader(const mx::FilePath& searchPath, mx::ElementPtr elem);
 
     /// Get Nano-gui shader
     GLShaderPtr ngShader() const { return _ngShader; }
@@ -76,7 +76,8 @@ class Material
 };
 
 void loadLibraries(const mx::StringVec& libraryNames, const mx::FilePath& searchPath, mx::DocumentPtr doc);
+void loadDocument(const mx::FilePath& filePath, mx::DocumentPtr& document, mx::DocumentPtr stdLib, std::vector<mx::ElementPtr>& elements);
 
-StringPair generateSource(const mx::FilePath& filePath, const mx::FilePath& searchPath, mx::DocumentPtr stdLib, mx::HwShaderPtr& hwShader);
+StringPair generateSource(const mx::FilePath& searchPath, mx::HwShaderPtr& hwShader, mx::ElementPtr elem);
 
 #endif // MATERIALXVIEW_MATERIAL_H

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -144,7 +144,7 @@ void Viewer::updateMaterialComboBox()
     performLayout();
 }
 
-void Viewer::setElementToRender(int index)
+bool Viewer::setElementToRender(int index)
 {
     mx::ElementPtr elem = index >= 0 ? _renderableElements[index] : nullptr;
     if (elem)
@@ -153,8 +153,10 @@ void Viewer::setElementToRender(int index)
         if (_material)
         {
             _material->bindMesh(_mesh);
+            return true;
         }
     }
+    return false;
 }
 
 bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
@@ -200,38 +202,36 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
         return true;
     }
 
-    if (key == GLFW_KEY_RIGHT && action == GLFW_PRESS)
+    if ((key == GLFW_KEY_RIGHT || key == GLFW_KEY_LEFT) && action == GLFW_PRESS)
     {
         int elementSize = static_cast<int>(_renderableElements.size());
         if (elementSize > 1)
         {
-            _renderableElementIndex = (_renderableElementIndex + 1) % elementSize;
+            int newIndex = 0;
+            if (key == GLFW_KEY_RIGHT)
+            {
+                newIndex = (_renderableElementIndex + 1) % elementSize;
+            }
+            else
+            {
+                newIndex = (_renderableElementIndex + elementSize - 1) % elementSize;
+            }
             try
             {
-                setElementToRender(_renderableElementIndex);
+                if (setElementToRender(newIndex))
+                {
+                    _materialComboBox->setSelectedIndex(newIndex);
+                    _renderableElementIndex = newIndex;
+                }
             }
             catch (std::exception& e)
             {
                 new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Shader Generation Error", e.what());
             }
         }
+        return true;
     }
-    if (key == GLFW_KEY_LEFT && action == GLFW_PRESS)
-    {
-        int elementSize = static_cast<int>(_renderableElements.size());
-        if (elementSize > 1)
-        {
-            _renderableElementIndex = (_renderableElementIndex + elementSize - 1) % elementSize;
-            try
-            {
-                setElementToRender(_renderableElementIndex);
-            }
-            catch (std::exception& e)
-            {
-                new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Shader Generation Error", e.what());
-            }
-        }
-    }
+
     return false;
 }
 

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -138,7 +138,7 @@ void Viewer::updateMaterialComboBox()
     std::vector<std::string> items;
     for (size_t i = 0; i < _renderableElements.size(); i++)
     {
-        items.push_back(_renderableElements[i]->getName());
+        items.push_back(_renderableElements[i]->getNamePath());
     }
     _materialComboBox->setItems(items);
     performLayout();
@@ -146,7 +146,7 @@ void Viewer::updateMaterialComboBox()
 
 bool Viewer::setElementToRender(int index)
 {
-    mx::ElementPtr elem = index >= 0 ? _renderableElements[index] : nullptr;
+    mx::ElementPtr elem = (index >= 0 && index < _renderableElements.size()) ? _renderableElements[index] : nullptr;
     if (elem)
     {
         _material = Material::generateShader(_searchPath, elem);
@@ -169,7 +169,10 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
     {
         try 
         {
+            loadDocument(_materialFilename, _materialDocument, _stdLib, _renderableElements);
+            _renderableElementIndex = _renderableElements.size() ? 0 : -1;
             setElementToRender(_renderableElementIndex);
+            updateMaterialComboBox();
         }
         catch (std::exception& e)
         {
@@ -202,6 +205,7 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
         return true;
     }
 
+    // Allow left and right keys to cycle through the renderable elements
     if ((key == GLFW_KEY_RIGHT || key == GLFW_KEY_LEFT) && action == GLFW_PRESS)
     {
         int elementSize = static_cast<int>(_renderableElements.size());

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -137,7 +137,7 @@ void Viewer::updatePropertySheet()
     layout->setMargin(10);
     layout->setColStretch(2, 1);
     _propertySheetWindow->setPosition(previousPosition);
-    _propertySheetWindow->setVisible(true);
+    _propertySheetWindow->setVisible(false); // TODO: Add toggle for this display
     _propertySheetWindow->setLayout(layout);
     _propertySheet->setWindow(_propertySheetWindow);
 
@@ -318,6 +318,7 @@ Viewer::Viewer() :
     });
 
     _materialComboBox = new ng::ComboBox(_window, {"None"});
+    _materialComboBox->setChevronIcon(-1);
     _materialComboBox->setCallback([this](int choice) {
         mx::ElementPtr elem = choice >= 0 ? _renderableElements[choice] : nullptr;
         _material = Material::generateShader(_searchPath, elem);

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -44,8 +44,9 @@ void addValueToForm(mx::ValuePtr value, const std::string& label, ng::FormHelper
         mx::Color2 v = value->asA<mx::Color2>();
         ng::Color c;
         c.r() = v[0];
-        c.g() = v[1];
+        c.g() = 0.0f;
         c.b() = 0.0f;
+        c.w() = v[1];
         form.addVariable(label, c, false);
     }
     else if (value->isA<mx::Color3>())
@@ -55,6 +56,7 @@ void addValueToForm(mx::ValuePtr value, const std::string& label, ng::FormHelper
         c.r() = v[0];
         c.g() = v[1];
         c.b() = v[2];
+        c.w() = 1.0;
         form.addVariable(label, c, false);
     }
     else if (value->isA<mx::Color4>())
@@ -64,6 +66,7 @@ void addValueToForm(mx::ValuePtr value, const std::string& label, ng::FormHelper
         c.r() = v[0];
         c.g() = v[1];
         c.b() = v[2];
+        c.w() = v[3];
         form.addVariable(label, c, false);
     }
     else if (value->isA<mx::Vector2>())
@@ -73,6 +76,7 @@ void addValueToForm(mx::ValuePtr value, const std::string& label, ng::FormHelper
         c.r() = v[0];
         c.g() = v[1];
         c.b() = 0.0f;
+        c.w() = 1.0f;
         form.addVariable(label, c, false);
     }
     else if (value->isA<mx::Vector3>())
@@ -82,6 +86,7 @@ void addValueToForm(mx::ValuePtr value, const std::string& label, ng::FormHelper
         c.r() = v[0];
         c.g() = v[1];
         c.b() = v[2];
+        c.w() = 1.0;
         form.addVariable(label, c, false);
     }
     else if (value->isA<mx::Vector4>())
@@ -91,7 +96,16 @@ void addValueToForm(mx::ValuePtr value, const std::string& label, ng::FormHelper
         c.r() = v[0];
         c.g() = v[1];
         c.b() = v[2];
+        c.w() = v[3];
         form.addVariable(label, c, false);
+    }
+    else if (value->isA<std::string>())
+    {
+        std::string v = value->asA<std::string>();
+        if (!v.empty())
+        {
+            form.addVariable(label, v, false);
+        }
     }
 }
 
@@ -245,7 +259,11 @@ void Viewer::updatePropertySheet()
 }
 
 Viewer::Viewer() :
-    ng::Screen(ng::Vector2i(1280, 960), "MaterialXView"),
+    ng::Screen(ng::Vector2i(1280, 960), "MaterialXView",
+        /*resizable*/ true, /*fullscreen*/false, /*colorBits*/ 16,
+        /*alphaBits*/ 16, /*depthBits*/ 24, /*stencilBits*/ 8,
+        /* nSamples */ 8,
+        /* glMajor*/ 4, /*glMinor*/ 0),
     _translationActive(false),
     _translationStart(0, 0),
     _envSamples(MIN_ENV_SAMPLES)
@@ -291,9 +309,9 @@ Viewer::Viewer() :
             {
                 loadDocument(_materialFilename, _materialDocument, _stdLib, _renderableElements);
                 _renderableElementIndex = _renderableElements.size() ? 0 : -1;
-                setElementToRender(_renderableElementIndex);
                 updateMaterialComboBox();
                 updatePropertySheet();
+                setElementToRender(_renderableElementIndex);
             }
             catch (std::exception& e)
             {
@@ -346,8 +364,8 @@ Viewer::Viewer() :
     {
         loadDocument(_materialFilename, _materialDocument, _stdLib, _renderableElements);
         _renderableElementIndex = _renderableElements.size() ? 0 : -1;
-        setElementToRender(_renderableElementIndex);
         updateMaterialComboBox();
+        setElementToRender(_renderableElementIndex);
     }
     catch (std::exception& e)
     {
@@ -402,9 +420,9 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
         {
             loadDocument(_materialFilename, _materialDocument, _stdLib, _renderableElements);
             _renderableElementIndex = _renderableElements.size() ? 0 : -1;
-            setElementToRender(_renderableElementIndex);
             updateMaterialComboBox();
             updatePropertySheet();
+            setElementToRender(_renderableElementIndex);
         }
         catch (std::exception& e)
         {

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -259,11 +259,7 @@ void Viewer::updatePropertySheet()
 }
 
 Viewer::Viewer() :
-    ng::Screen(ng::Vector2i(1280, 960), "MaterialXView",
-        /*resizable*/ true, /*fullscreen*/false, /*colorBits*/ 16,
-        /*alphaBits*/ 16, /*depthBits*/ 24, /*stencilBits*/ 8,
-        /* nSamples */ 0, // Leave off as turning this on make sRGB display convertion to be disabled
-        /* glMajor*/ 4, /*glMinor*/ 0),
+    ng::Screen(ng::Vector2i(1280, 960), "MaterialXView"),
     _translationActive(false),
     _translationStart(0, 0),
     _envSamples(MIN_ENV_SAMPLES)

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -262,7 +262,7 @@ Viewer::Viewer() :
     ng::Screen(ng::Vector2i(1280, 960), "MaterialXView",
         /*resizable*/ true, /*fullscreen*/false, /*colorBits*/ 16,
         /*alphaBits*/ 16, /*depthBits*/ 24, /*stencilBits*/ 8,
-        /* nSamples */ 8,
+        /* nSamples */ 0, // Leave off as turning this on make sRGB display convertion to be disabled
         /* glMajor*/ 4, /*glMinor*/ 0),
     _translationActive(false),
     _translationStart(0, 0),

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -46,6 +46,9 @@ class Viewer : public ng::Screen
                                mx::Matrix44& view,
                                mx::Matrix44& proj);
 
+    void setElementToRender(int index);
+    void updateMaterialComboBox();
+
   private:
     ng::Window* _window;
     std::unique_ptr<Mesh> _mesh;
@@ -64,6 +67,9 @@ class Viewer : public ng::Screen
     mx::DocumentPtr _materialDocument;
     std::vector<mx::ElementPtr> _renderableElements;
     int _renderableElementIndex;
+    ng::ComboBox* _materialComboBox;
+    bool _materialComboBoxDirty;
+
     mx::ImageHandlerPtr _imageHandler;
 };
 

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -46,7 +46,9 @@ class Viewer : public ng::Screen
                                mx::Matrix44& view,
                                mx::Matrix44& proj);
 
+    /// Set the current element to render in the list of renderables
     bool setElementToRender(int index);
+    /// Update the material list combo box 
     void updateMaterialComboBox();
 
   private:
@@ -65,10 +67,13 @@ class Viewer : public ng::Screen
 
     mx::DocumentPtr _stdLib;
     mx::DocumentPtr _materialDocument;
+
+    /// List of renderable elements within a given document
     std::vector<mx::ElementPtr> _renderableElements;
+    /// Index to indicate which is the "active" element to render in the list
     int _renderableElementIndex;
+    /// Associated UI combo box to display the list
     ng::ComboBox* _materialComboBox;
-    bool _materialComboBoxDirty;
 
     mx::ImageHandlerPtr _imageHandler;
 };

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -46,7 +46,7 @@ class Viewer : public ng::Screen
                                mx::Matrix44& view,
                                mx::Matrix44& proj);
 
-    void setElementToRender(int index);
+    bool setElementToRender(int index);
     void updateMaterialComboBox();
 
   private:

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -78,8 +78,12 @@ class Viewer : public ng::Screen
     /// Associated UI combo box to display the list
     ng::ComboBox* _materialComboBox;
 
+    /// Parent form for display property sheet
     ng::FormHelper* _propertySheet;
+    /// Window holding property sheet.
     ng::Window* _propertySheetWindow;
+    /// Option as to whether to show non-editable inputs. 
+    bool _showNonEditableInputs;
 
     mx::ImageHandlerPtr _imageHandler;
 };

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -61,6 +61,9 @@ class Viewer : public ng::Screen
     int _envSamples;
 
     mx::DocumentPtr _stdLib;
+    mx::DocumentPtr _materialDocument;
+    std::vector<mx::ElementPtr> _renderableElements;
+    int _renderableElementIndex;
     mx::ImageHandlerPtr _imageHandler;
 };
 

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -7,6 +7,7 @@
 
 #include <nanogui/glutil.h>
 #include <nanogui/screen.h>
+#include <nanogui/formhelper.h>
 
 namespace mx = MaterialX;
 namespace ng = nanogui;
@@ -51,6 +52,8 @@ class Viewer : public ng::Screen
     /// Update the material list combo box 
     void updateMaterialComboBox();
 
+    void updatePropertySheet();
+
   private:
     ng::Window* _window;
     std::unique_ptr<Mesh> _mesh;
@@ -74,6 +77,9 @@ class Viewer : public ng::Screen
     int _renderableElementIndex;
     /// Associated UI combo box to display the list
     ng::ComboBox* _materialComboBox;
+
+    ng::FormHelper* _propertySheet;
+    ng::Window* _propertySheetWindow;
 
     mx::ImageHandlerPtr _imageHandler;
 };


### PR DESCRIPTION
When scanning a document, keep track of a list of elements which can be rendered. This includes
shader references and outputs. We prune out any nodes which have a URI which is indicative that
they are from imported libraries (which includes any stdlib definitions).

A new combo box is used to list the elements and allow choosing a different element to display. The LEFT and RIGHT arrow keys also allow moving back and forth in the list.

A new "Property Sheet" widget is added to examine the current element being rendered and display it's inputs and parameters. For outputs, the upstream connected node is used. For shader refers bindinputs and bindparameters are shown by default. A flag has been added to allow display all nodedef properties but these are non-editable and are thus currently hidden. The property sheets widgets are currently non-editable.