### PR TITLE
Add a checkbox to toggle use of stdlib. 

### DIFF
--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -14,7 +14,10 @@ mx::DocumentPtr loadDocument(const mx::FilePath& filePath, mx::DocumentPtr stdLi
 {
     mx::DocumentPtr doc = mx::createDocument();
     mx::readFromXmlFile(doc, filePath);
-    doc->importLibrary(stdLib);
+    if (stdLib)
+    {
+        doc->importLibrary(stdLib);
+    }
 
     return doc;
 }

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -79,7 +79,8 @@ Viewer::Viewer(const mx::StringVec& libraryFolders,
     _nodeRemap(nodeRemap),
     _envSamples(DEFAULT_ENV_SAMPLES),
     _geomIndex(0),
-    _elemIndex(0)
+    _elemIndex(0),
+    _usestdLib(true)
 {
     _window = new ng::Window(this, "Viewer Options");
     _window->setPosition(ng::Vector2i(15, 15));
@@ -110,6 +111,13 @@ Viewer::Viewer(const mx::StringVec& libraryFolders,
         mProcessEvents = true;
     });
 
+    ng::CheckBox* useStandardLib = new ng::CheckBox(_window, "Use Standard Library");
+    useStandardLib->setChecked(_usestdLib);
+    useStandardLib->setCallback([this](bool state)
+    {
+        _usestdLib = state;
+    });
+
     ng::Button* materialButton = new ng::Button(_window, "Load Material");
     materialButton->setCallback([this]()
     {
@@ -120,7 +128,8 @@ Viewer::Viewer(const mx::StringVec& libraryFolders,
             _materialFilename = filename;
             try
             {
-                _contentDocument = loadDocument(_materialFilename, _stdLib);
+                // Load document with default std lib if required.
+                _contentDocument = loadDocument(_materialFilename, _usestdLib ? _stdLib : nullptr);
                 remapNodes(_contentDocument, _nodeRemap);
                 updateElementSelections();
                 setElementSelection(0);

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -97,6 +97,7 @@ class Viewer : public ng::Screen
     mx::StringVec _libraryFolders;
     mx::FileSearchPath _searchPath;
     mx::StringMap _nodeRemap;
+    bool _usestdLib;
 
     mx::FilePath _materialFilename;
     int _envSamples;


### PR DESCRIPTION
This is helpful when mtlx use includes.
for example the mtlx below includes libraries which might conflict with libraries that are already loaded.

`<?xml version="1.0"?>
<materialx version="1.36">
  <xi:include href="F:\source\matop\3rdparty\materialx\documents\Libraries\stdlib\stdlib_defs.mtlx" />
  <xi:include href="F:\source\matop\3rdparty\materialx\documents\Libraries\stdlib\stdlib_ng.mtlx" />
  <xi:include href="F:\source\matop\3rdparty\materialx\documents\Libraries\pbrlib\pbrlib_defs.mtlx" />
  <xi:include href="F:\source\matop\3rdparty\materialx\documents\Libraries\pbrlib\pbrlib_ng.mtlx" />
  <xi:include href="F:\source\matop\3rdparty\materialx\documents\Libraries\stdlib\genglsl\cm_genglsl_impl.mtlx" />
  <xi:include href="F:\source\matop\3rdparty\materialx\documents\Libraries\stdlib\genglsl\stdlib_genglsl_impl.mtlx" />
  <xi:include href="F:\source\matop\3rdparty\materialx\documents\Libraries\pbrlib\genglsl\pbrlib_genglsl_impl.mtlx" />
  <material name="Anodized-Red-Rough">
    <shaderref name="shaderref1" node="standard_surface">
      <bindinput name="base_color" type="color3" value="0.7, 0.1, 0.1" />
      <bindinput name="specular_color" type="color3" value="1, 1, 1" />
      <bindinput name="specular_anisotropy" type="float" value="0" />
      <bindinput name="specular_roughness" type="float" value="0.547723" />
      <bindinput name="specular_rotation" type="float" value="0" />
      <bindinput name="specular_IOR" type="float" value="1.5" />
      <bindinput name="metalness" type="float" value="1" />
      <bindinput name="thin_walled" type="boolean" value="false" />
      <bindinput name="coat" type="float" value="0" />
    </shaderref>
  </material>
  <look name="look1">
    <materialassign name="materialassign1" material="Anodized-Red-Rough" collection="collection1" />
  </look>
  <collection name="collection1" geomprefix="/*" />
</materialx>`

![usestdlib](https://user-images.githubusercontent.com/1727158/51719617-fdb28480-1ffe-11e9-8210-e816007097f1.png)
