### PR TITLE
Use CopyOptions while loadDocument

### DIFF
--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -14,7 +14,9 @@ mx::DocumentPtr loadDocument(const mx::FilePath& filePath, mx::DocumentPtr stdLi
 {
     mx::DocumentPtr doc = mx::createDocument();
     mx::readFromXmlFile(doc, filePath);
-    doc->importLibrary(stdLib);
+    mx::CopyOptions copyOptions;
+    copyOptions.skipDuplicateElements = true;
+    doc->importLibrary(stdLib, &copyOptions);
 
     return doc;
 }


### PR DESCRIPTION
Enable skipDuplicateElements.